### PR TITLE
fix: portfinder import is case-sensitive

### DIFF
--- a/.electron-vite/dev-runner.ts
+++ b/.electron-vite/dev-runner.ts
@@ -4,7 +4,7 @@ import electron from 'electron';
 import chalk from 'chalk';
 import { join } from 'path';
 import { watch } from 'rollup';
-import Portfinder from 'Portfinder';
+import Portfinder from 'portfinder';
 import config from '../config'
 import { say } from 'cfonts';
 import { spawn } from 'child_process';

--- a/src/renderer/i18n/languages/en.ts
+++ b/src/renderer/i18n/languages/en.ts
@@ -27,7 +27,7 @@ export const lang = {
         viewMessage: "view message",
         openNewWindow: "Open new window",
         simulatedCrash: "Simulated crash",
-        changeLanguage: "Change language",
+        changeLanguage: "切换语言",
         ForcedUpdate: "Forced Update Mode",
         printDemo: "Print demo",
         incrementalUpdateTest: "Incremental Update test",

--- a/src/renderer/i18n/languages/zh-cn.ts
+++ b/src/renderer/i18n/languages/zh-cn.ts
@@ -27,7 +27,7 @@ export const lang = {
         viewMessage: "查看消息",
         openNewWindow: "打开新窗口",
         simulatedCrash: "模拟崩溃",
-        changeLanguage: "切换语言",
+        changeLanguage: "Change language",
         ForcedUpdate: "强制更新模式",
         printDemo: "打印例子",
         incrementalUpdateTest: "增量更新测试",


### PR DESCRIPTION
Changed import from "Portfinder" to "portfinder" which was breaking Linux builds.
Tested on Linux and MacOS.